### PR TITLE
Update bench to show avg

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -7,8 +7,8 @@ Performance comparison between **sqlparser-ts** and **node-sql-parser**.
 | Metric | sqlparser-ts | node-sql-parser | Winner |
 |--------|-------------|-----------------|--------|
 | Package Size | **6.3 MB** | 88.1 MB | sqlparser-ts (**13.9x smaller**) |
-| Parse (avg) | **55,935 ms** | 115,071 ms | sqlparser-ts (**2.06x faster**) |
-| Format (avg) | **24,372 ms** | 130,084 ms | sqlparser-ts (**5.34x faster**) |
+| Parse (avg per call) | **34.3 μs** | 70.6 μs | sqlparser-ts (**2.06x faster**) |
+| Format (avg per call) | **14.9 μs** | 79.8 μs | sqlparser-ts (**5.35x faster**) |
 
 ## Test Configuration
 
@@ -74,7 +74,7 @@ cd benchmark
 npm install
 
 # Run all benchmarks, generate figures and update readme automatically
-node cli.js bench -i 1000
+node cli.js bench
 
 # Individual commands
 node cli.js verify              # Compare parser outputs

--- a/benchmark/cli.js
+++ b/benchmark/cli.js
@@ -652,8 +652,8 @@ Performance comparison between **sqlparser-ts** and **node-sql-parser**.
 | Metric | sqlparser-ts | node-sql-parser | Winner |
 |--------|-------------|-----------------|--------|
 | Package Size | **${formatSize(sizeResults.sqlparserRs)}** | ${formatSize(sizeResults.nodeSqlParser)} | sqlparser-ts (**${sizeResults.ratio}x smaller**) |
-| Parse (avg) | **${fmtMs(parseAvg.rs)}** | ${fmtMs(parseAvg.node)} | sqlparser-ts (**${(parseAvg.node / parseAvg.rs).toFixed(2)}x faster**) |
-| Format (avg) | **${fmtMs(formatAvg.rs)}** | ${fmtMs(formatAvg.node)} | sqlparser-ts (**${(formatAvg.node / formatAvg.rs).toFixed(2)}x faster**) |
+| Parse (avg per call) | **${fmtAvgCall(parseAvg.rs)}** | ${fmtAvgCall(parseAvg.node)} | sqlparser-ts (**${(parseAvg.node / parseAvg.rs).toFixed(2)}x faster**) |
+| Format (avg per call) | **${fmtAvgCall(formatAvg.rs)}** | ${fmtAvgCall(formatAvg.node)} | sqlparser-ts (**${(formatAvg.node / formatAvg.rs).toFixed(2)}x faster**) |
 
 ## Test Configuration
 
@@ -719,7 +719,7 @@ cd benchmark
 npm install
 
 # Run all benchmarks, generate figures and update readme automatically
-node cli.js bench -i 1000
+node cli.js bench
 
 # Individual commands
 node cli.js verify              # Compare parser outputs


### PR DESCRIPTION
## Why

totall -> avg

## How

- update cli 
- update bench data
  - Parse (avg per call):                                                                                                     
    - sqlparser-ts: (34.0 + 34.7 + 34.2) / 3 = 34.3 μs                                                                        
    - node-sql-parser: (64.2 + 96.4 + 51.1) / 3 = 70.6 μs                                                                                                                                                                                            
  - Format (avg per call):                                                                                                    
    - sqlparser-ts: (15.3 + 15.0 + 14.5) / 3 = 14.9 μs                                                                        
    - node-sql-parser: (74.0 + 106.6 + 58.9) / 3 = 79.8 μs 
