### PR TITLE
Add write permissions in check-upstream workflow

### DIFF
--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 9 * * 1'
   workflow_dispatch:
 
+permissions:
+  issues: write
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

ci failed since no permission

## How

Add write permissions in check-upstream workflow
